### PR TITLE
Support for Ubuntu 18.04 with the fix for IP_ADDR

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,29 +3,29 @@
 
 servers = [
     {
-        :name => "k8s-head",
+        :name => "k8s-master",
         :type => "master",
-        :box => "ubuntu/xenial64",
-        :box_version => "20180831.0.0",
-        :eth1 => "192.168.205.10",
+        :box => "ubuntu/bionic64",
+        :box_version => "20190307.0.0",
+        :eth1 => "192.168.192.10",
         :mem => "2048",
         :cpu => "2"
     },
     {
-        :name => "k8s-node-1",
+        :name => "k8s-node1",
         :type => "node",
-        :box => "ubuntu/xenial64",
-        :box_version => "20180831.0.0",
-        :eth1 => "192.168.205.11",
+        :box => "ubuntu/bionic64",
+        :box_version => "20190307.0.0",
+        :eth1 => "192.168.192.11",
         :mem => "2048",
         :cpu => "2"
     },
     {
-        :name => "k8s-node-2",
+        :name => "k8s-node2",
         :type => "node",
-        :box => "ubuntu/xenial64",
-        :box_version => "20180831.0.0",
-        :eth1 => "192.168.205.12",
+        :box => "ubuntu/bionic64",
+        :box_version => "20190307.0.0",
+        :eth1 => "192.168.192.12",
         :mem => "2048",
         :cpu => "2"
     }
@@ -34,23 +34,21 @@ servers = [
 # This script to install k8s using kubeadm will get executed after a box is provisioned
 $configureBox = <<-SCRIPT
 
-    # install docker v17.03
+    # install docker-ce
     # reason for not using docker provision is that it always installs latest version of the docker, but kubeadm requires 17.03 or older
-    apt-get update
-    apt-get install -y apt-transport-https ca-certificates curl software-properties-common
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-    add-apt-repository "deb https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") $(lsb_release -cs) stable"
-    apt-get update && apt-get install -y docker-ce=$(apt-cache madison docker-ce | grep 17.03 | head -1 | awk '{print $3}')
+    sudo apt-get update
+    sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common gnupg-agent
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+    sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+    sudo apt-get update && sudo apt-get install -y docker-ce docker-ce-cli containerd.io
 
     # run docker commands as vagrant user (sudo not required)
     usermod -aG docker vagrant
 
     # install kubeadm
-    apt-get install -y apt-transport-https curl
+    apt-get update && apt-get install -y apt-transport-https curl
     curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-    cat <<EOF >/etc/apt/sources.list.d/kubernetes.list
-    deb http://apt.kubernetes.io/ kubernetes-xenial main
-EOF
+    sudo add-apt-repository "deb https://apt.kubernetes.io/ kubernetes-xenial main"
     apt-get update
     apt-get install -y kubelet kubeadm kubectl
     apt-mark hold kubelet kubeadm kubectl
@@ -62,7 +60,7 @@ EOF
     sudo sed -i '/ swap / s/^\(.*\)$/#\1/g' /etc/fstab
 
     # ip of this box
-    IP_ADDR=`ifconfig enp0s8 | grep Mask | awk '{print $2}'| cut -f2 -d:`
+    IP_ADDR=`ifconfig enp0s8 | grep mask | awk '{print $2}'| cut -f2 -d:`
     # set node-ip
     sudo sed -i "/^[^#]*KUBELET_EXTRA_ARGS=/c\KUBELET_EXTRA_ARGS=--node-ip=$IP_ADDR" /etc/default/kubelet
     sudo systemctl restart kubelet
@@ -75,7 +73,7 @@ $configureMaster = <<-SCRIPT
 
     # install k8s master
     HOST_NAME=$(hostname -s)
-    kubeadm init --apiserver-advertise-address=$IP_ADDR --apiserver-cert-extra-sans=$IP_ADDR  --node-name $HOST_NAME --pod-network-cidr=172.16.0.0/16
+    kubeadm init --apiserver-advertise-address=$IP_ADDR --apiserver-cert-extra-sans=$IP_ADDR  --node-name $HOST_NAME --pod-network-cidr=192.168.0.0/16
 
     #copying credentials to regular user - vagrant
     sudo --user=vagrant mkdir -p /home/vagrant/.kube
@@ -84,10 +82,10 @@ $configureMaster = <<-SCRIPT
 
     # install Calico pod network addon
     export KUBECONFIG=/etc/kubernetes/admin.conf
-    kubectl apply -f https://raw.githubusercontent.com/ecomm-integration-ballerina/kubernetes-cluster/master/calico/rbac-kdd.yaml
-    kubectl apply -f https://raw.githubusercontent.com/ecomm-integration-ballerina/kubernetes-cluster/master/calico/calico.yaml
+    kubectl apply -f https://raw.githubusercontent.com/polycube-network/polycube/c08c4f84ccbaf9788a41e813eb87883fc63fe80d/src/components/k8s/standalone_etcd.yaml
+    kubectl apply -f https://raw.githubusercontent.com/polycube-network/polycube/c08c4f84ccbaf9788a41e813eb87883fc63fe80d/src/components/k8s/pcn-k8s.yaml
 
-    kubeadm token create --print-join-command >> /etc/kubeadm_join_cmd.sh
+    kubeadm token create --print-join-command > /etc/kubeadm_join_cmd.sh
     chmod +x /etc/kubeadm_join_cmd.sh
 
     # required for setting up password less ssh between guest VMs
@@ -99,7 +97,7 @@ SCRIPT
 $configureNode = <<-SCRIPT
     echo "This is worker"
     apt-get install -y sshpass
-    sshpass -p "vagrant" scp -o StrictHostKeyChecking=no vagrant@192.168.205.10:/etc/kubeadm_join_cmd.sh .
+    sshpass -p "vagrant" scp -o StrictHostKeyChecking=no vagrant@192.168.192.10:/etc/kubeadm_join_cmd.sh .
     sh ./kubeadm_join_cmd.sh
 SCRIPT
 
@@ -116,7 +114,7 @@ Vagrant.configure("2") do |config|
             config.vm.provider "virtualbox" do |v|
 
                 v.name = opts[:name]
-            	 v.customize ["modifyvm", :id, "--groups", "/Ballerina Development"]
+            	v.customize ["modifyvm", :id, "--groups", "/PCN Development"]
                 v.customize ["modifyvm", :id, "--memory", opts[:mem]]
                 v.customize ["modifyvm", :id, "--cpus", opts[:cpu]]
 
@@ -137,4 +135,4 @@ Vagrant.configure("2") do |config|
 
     end
 
-end 
+end


### PR DESCRIPTION
```
:box => "ubuntu/bionic64",
:box_version => "20190307.0.0",
```
- Update Ubuntu 18.04 (64 bit)

```
IP_ADDR=`ifconfig enp0s8 | grep mask | awk '{print $2}'| cut -f2 -d:`
```
- `Mask` was incorrect for grep, changed to `mask`